### PR TITLE
ENH: Update landmark registration module for updated markups

### DIFF
--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -121,9 +121,10 @@ class LandmarksWidget(pqWidget):
     movingIndexAttribute = fiducialList.GetAttribute('Markups.MovingMarkupIndex')
     if self.movingView and movingIndexAttribute:
       movingIndex = int(movingIndexAttribute)
-      landmarkName = fiducialList.GetNthMarkupLabel(movingIndex)
-      self.pickLandmark(landmarkName,clearMovingView=False)
-      self.emit("landmarkMoved(landmarkName)", (landmarkName,))
+      if movingIndex < fiducialList.GetNumberOfControlPoints():
+        landmarkName = fiducialList.GetNthMarkupLabel(movingIndex)
+        self.pickLandmark(landmarkName,clearMovingView=False)
+        self.emit("landmarkMoved(landmarkName)", (landmarkName,))
 
   def onFiducialEndMoving(self,fiducialList):
     """Callback when fiducialList's point is done moving."""


### PR DESCRIPTION
- Markups can no longer be placed if it is hidden, so the landmark list corresponding to the slice view that is being hovered over is now activated.
- Checks in multiple locations to not process added markups if the position has not been defined (preview or unplaced not yet placed)

re #29