### PR TITLE
ENH: use a more reasonable grid size

### DIFF
--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -84,7 +84,6 @@ class ThinPlatePlugin(RegistrationPlugin):
 
   def onExportGrid(self):
     """Converts the current thin plate transform to a grid"""
-    self.hotUpdateButton = None
     state = self.registrationState()
 
     # since the transform is ras-to-ras, we find the extreme points
@@ -99,6 +98,7 @@ class ThinPlatePlugin(RegistrationPlugin):
     maxes = list(map(int,map(ceil,rasBounds[1::2])))
     boundSize = [m - o for m,o in zip(maxes,origin) ]
     spacing = state.fixed.GetSpacing()
+    spacing = [max(spacing)*5]*3
     samples = [ceil(int(b / s)) for b,s in zip(boundSize,spacing)]
     extent = [0,]*6
     extent[::2] = [0,]*3
@@ -107,7 +107,7 @@ class ThinPlatePlugin(RegistrationPlugin):
 
     toGrid = vtk.vtkTransformToGrid()
     toGrid.SetGridOrigin(origin)
-    toGrid.SetGridSpacing(state.fixed.GetSpacing())
+    toGrid.SetGridSpacing(spacing)
     toGrid.SetGridExtent(extent)
     toGrid.SetInput(state.transform.GetTransformFromParent()) # same in VTKv 5 & 6
     toGrid.Update()


### PR DESCRIPTION
Previously the exported grid transform was the size of the volumes
but this resulted in huge transforms.

Now we use 5 times the max spacing so computation is very fast
and filesize is fine.  No visible loss of quality.

In future we should expose this as a parameter.