### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/LandmarkRegistration.py
+++ b/LandmarkRegistration.py
@@ -1,5 +1,3 @@
-from __future__ import division
-from __future__ import print_function
 import os, string
 import time
 import vtk, qt, ctk, slicer
@@ -627,7 +625,7 @@ class LandmarkRegistrationWidget(ScriptedLoadableModuleWidget):
     if not sys.path.__contains__(p):
       sys.path.insert(0,p)
     for subModuleName in ("pqWidget", "Visualization", "Landmarks", ):
-      fp = open(filePath, "r")
+      fp = open(filePath)
       globals()[subModuleName] = imp.load_module(
           subModuleName, fp, filePath, ('.py', 'r', imp.PY_SOURCE))
       fp.close()
@@ -957,7 +955,7 @@ class LandmarkRegistrationLogic(ScriptedLoadableModuleLogic):
       fiducialCount = fiducialNodes[0].GetNumberOfFiducials()
       for fiducialNode in fiducialNodes:
         if fiducialCount != fiducialNode.GetNumberOfFiducials():
-          raise Exception("Fiducial counts don't match {0}".format(fiducialCount))
+          raise Exception(f"Fiducial counts don't match {fiducialCount}")
       point = [0,]*3
       indices = range(fiducialCount)
       for fiducials,volumeNode in zip(fiducialNodes,volumeNodes):
@@ -1203,7 +1201,7 @@ class LandmarkRegistrationTest(ScriptedLoadableModuleTest):
     center = (int(fixedAxialView.width/2), int(fixedAxialView.height/2))
     offset = [element+100 for element in center]
     slicer.util.clickAndDrag(fixedAxialView,start=center,end=center, steps=0)
-    self.delayDisplay('Added a landmark, translate to drag at %s to %s' % (center,offset), 200)
+    self.delayDisplay(f'Added a landmark, translate to drag at {center} to {offset}', 200)
 
     slicer.util.clickAndDrag(fixedAxialView,button='Middle', start=center,end=offset,steps=10)
     self.delayDisplay('dragged to translate', 200)
@@ -1269,7 +1267,7 @@ class LandmarkRegistrationTest(ScriptedLoadableModuleTest):
     # enter picking mode
     w.landmarksWidget.addLandmark()
     slicer.util.clickAndDrag(fixedAxialView,start=center,end=offset, steps=10)
-    self.delayDisplay('Added a landmark, translate to drag at %s to %s' % (center,offset), 200)
+    self.delayDisplay(f'Added a landmark, translate to drag at {center} to {offset}', 200)
 
     import time, math
     times = []

--- a/RegistrationLib/AffinePlugin.py
+++ b/RegistrationLib/AffinePlugin.py
@@ -48,11 +48,11 @@ class AffinePlugin(RegistrationPlugin):
   sourceFile = __file__
 
   def __init__(self,parent=None):
-    super(AffinePlugin,self).__init__(parent)
+    super().__init__(parent)
 
   def create(self,registrationState):
     """Make the plugin-specific user interface"""
-    super(AffinePlugin,self).create(registrationState)
+    super().create(registrationState)
 
     self.linearMode = "Rigid"
 
@@ -85,7 +85,7 @@ class AffinePlugin(RegistrationPlugin):
 
   def destroy(self):
     """Clean up"""
-    super(AffinePlugin,self).destroy()
+    super().destroy()
 
   def onLandmarkMoved(self,state):
     """Perform the linear transform using the vtkLandmarkTransform class"""

--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import qt, slicer, os
 from . import pqWidget
 
@@ -10,7 +8,7 @@ class LandmarksWidget(pqWidget):
   """
 
   def __init__(self,logic):
-    super(LandmarksWidget,self).__init__()
+    super().__init__()
     self.logic = logic
     self.volumeNodes = []
     self.selectedLandmark = None # a landmark name

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 import time
 import vtk, qt, ctk, slicer
 from . import RegistrationPlugin
@@ -55,11 +52,11 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
   sourceFile = __file__
 
   def __init__(self,parent=None):
-    super(LocalBRAINSFitPlugin,self).__init__(parent)
+    super().__init__(parent)
 
   def create(self,registrationState):
     """Make the plugin-specific user interface"""
-    super(LocalBRAINSFitPlugin,self).create(registrationState)
+    super().create(registrationState)
 
 
     self.LocalBRAINSFitMode = "Small"
@@ -113,7 +110,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
 
   def destroy(self):
     """Clean up"""
-    super(LocalBRAINSFitPlugin,self).destroy()
+    super().destroy()
 
 
   def onLocalBRAINSFitMode(self,mode):

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 import time
 import qt, ctk, slicer
 from . import RegistrationPlugin
@@ -60,11 +57,11 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
   sitkUtils = None
 
   def __init__(self,parent=None):
-    super(LocalSimpleITKPlugin,self).__init__(parent)
+    super().__init__(parent)
 
   def create(self,registrationState):
     """Make the plugin-specific user interface"""
-    super(LocalSimpleITKPlugin,self).create(registrationState)
+    super().create(registrationState)
 
     # To avoid the overhead of importing SimpleITK during application
     # startup, the import of SimpleITK is delayed until it is needed.
@@ -124,7 +121,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
 
   def destroy(self):
     """Clean up"""
-    super(LocalSimpleITKPlugin,self).destroy()
+    super().destroy()
 
   def onLocalSimpleITKMode(self,mode):
     self.LocalSimpleITKMode = mode
@@ -196,7 +193,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     # minimal acceptable ROI size required by registration framework.
     if not all(fixedROISize > minimalROISize):
         import sys
-        sys.stderr.write("Fixed landmark {0} is too close to the image border, cannot register!\n".format(state.currentLandmarkName))
+        sys.stderr.write(f"Fixed landmark {state.currentLandmarkName} is too close to the image border, cannot register!\n")
         return
     if self.VerboseMode == "Full Verbose":  print("Fixed ROI: ",fixedMinIndexes.tolist(), fixedROISize.tolist())
     if timing: roiEnd = time.time()
@@ -221,7 +218,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     # minimal acceptable ROI size required by registration framework.
     if not all(movingROISize > minimalROISize):
         import sys
-        sys.stderr.write("Moving landmark {0} is too close to the image border, cannot register!\n".format(state.currentLandmarkName))
+        sys.stderr.write(f"Moving landmark {state.currentLandmarkName} is too close to the image border, cannot register!\n")
         return
     if self.VerboseMode == "Full Verbose": print("Moving ROI: ",movingMinIndexes.tolist(), movingROISize.tolist())
     if timing: roi2End = time.time()
@@ -262,9 +259,9 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
 
     # setup an observer
     def command_iteration(method) :
-      print("{0:3} = {1:10.5f} : {2}".format(method.GetOptimizerIteration(),
-                                             method.GetMetricValue(),
-                                             method.GetOptimizerPosition()))
+      print("{:3} = {:10.5f} : {}".format(method.GetOptimizerIteration(),
+                                          method.GetMetricValue(),
+                                          method.GetOptimizerPosition()))
     if self.VerboseMode == "Full Verbose":
       R.AddCommand( sitk.sitkIterationEvent, lambda: command_iteration(R) )
 
@@ -277,9 +274,9 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     if self.VerboseMode == "Full Verbose":
       print("-------")
       print(outTx)
-      print("Optimizer stop condition: {0}".format(R.GetOptimizerStopConditionDescription()))
-      print(" Iteration: {0}".format(R.GetOptimizerIteration()))
-      print(" Metric value: {0}".format(R.GetMetricValue()))
+      print(f"Optimizer stop condition: {R.GetOptimizerStopConditionDescription()}")
+      print(f" Iteration: {R.GetOptimizerIteration()}")
+      print(f" Metric value: {R.GetMetricValue()}")
 
 
     if timing: regEnd = time.time()

--- a/RegistrationLib/RegistrationPlugin.py
+++ b/RegistrationLib/RegistrationPlugin.py
@@ -22,7 +22,7 @@ comment = """
 # RegistrationPlugin
 #
 
-class RegistrationPlugin(object):
+class RegistrationPlugin:
   """ Base class for Registration plugins
   """
 

--- a/RegistrationLib/RegistrationState.py
+++ b/RegistrationLib/RegistrationState.py
@@ -1,9 +1,8 @@
-
 #
 # RegistrationState
 #
 
-class RegistrationState(object):
+class RegistrationState:
   """ Holds parameters of registration.
   An instance of this class is passed to virtual methods
   """

--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import vtk, qt, ctk, slicer
 from . import RegistrationPlugin
 
@@ -50,13 +48,13 @@ class ThinPlatePlugin(RegistrationPlugin):
   sourceFile = __file__
 
   def __init__(self,parent=None):
-    super(ThinPlatePlugin,self).__init__(parent)
+    super().__init__(parent)
 
     self.thinPlateTransform = None
 
   def create(self,registrationState):
     """Make the plugin-specific user interface"""
-    super(ThinPlatePlugin,self).create(registrationState)
+    super().create(registrationState)
     #
     # Thin Plate Spline Registration Pane
     #
@@ -80,7 +78,7 @@ class ThinPlatePlugin(RegistrationPlugin):
 
   def destroy(self):
     """Clean up"""
-    super(ThinPlatePlugin,self).destroy()
+    super().destroy()
 
   def onExportGrid(self):
     """Converts the current thin plate transform to a grid"""

--- a/RegistrationLib/Visualization.py
+++ b/RegistrationLib/Visualization.py
@@ -8,7 +8,7 @@ class VisualizationWidget(pqWidget):
   """
 
   def __init__(self,logic):
-    super(VisualizationWidget,self).__init__()
+    super().__init__()
     self.rockCount = 0
     self.rocking = False
     self.rockTimer = None

--- a/RegistrationLib/__init__.py
+++ b/RegistrationLib/__init__.py
@@ -14,4 +14,4 @@ for plugin in [
     __import__('RegistrationLib.%sPlugin' % plugin)
   except ImportError as details:
     import logging
-    logging.warning("Registration: Failed to import '%s' plugin: %s" % (plugin, details))
+    logging.warning(f"Registration: Failed to import '{plugin}' plugin: {details}")

--- a/RegistrationLib/pqWidget.py
+++ b/RegistrationLib/pqWidget.py
@@ -1,5 +1,4 @@
-
-class pqWidget(object):
+class pqWidget:
   """
   A "QWidget"-like widget class that manages provides some
   helper functionality (signals, slots...)


### PR DESCRIPTION
This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. This ultimately removes Python 2 compatibility.

See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Supporting_only_Python_3.6_and_above

re: https://github.com/Slicer/Slicer/issues/5626