### PR TITLE
ENH: Use non-deprecated markups API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 LandmarkRegistration
 ====================
 
-An interactive registration tool that manages viewing and manipulating of sets of fiducials
+An interactive registration tool that manages viewing and manipulating of sets of points
 
 
 This is a work-in-progress that will ultimately be an extension or core module of 3D Slicer.
@@ -17,10 +17,10 @@ To test: You need to checkout two repositories (1) this one and (2) https://gith
 
 If you checked them out to /tmp, then you can start slicer as follows:
 
-Linux: 
+Linux:
 
  ./Slicer --additional-module-paths /tmp/CompareVolumes /tmp/LandmarkRegistration
- 
+
 (on windows you run "Slicer.exe <args>" from a console.  On mac, you use "open Slicer.app <args>")
 
 Versions
@@ -39,9 +39,9 @@ Linear:
 * scroll to the Registration area and select Linear
 * enable the Registration Active checkbox (this will create a transformed volume)
 * pick Axi/Sag/Cor in the Visualization box (this will create a custom layout with fixed on top, moving in the middle, and fixed + transformed on the bottom)
-* place a fiducial on either the fixed or moving volumes (a corresponding one will be created on the other volume)
-* drag the fiducials in the fixed and moving volumes until they are on the same anatomical location.  The blended view will update automatically on mouse release.
-* place and adjust fiducials until registration is good.
+* place a point on either the fixed or moving volumes (a corresponding one will be created on the other volume)
+* drag the points in the fixed and moving volumes until they are on the same anatomical location.  The blended view will update automatically on mouse release.
+* place and adjust points until registration is good.
 * Option: Similarity mode is Rigid + Scale and can be good for some cross-subject registration
 
 Caveats

--- a/RegistrationLib/AffinePlugin.py
+++ b/RegistrationLib/AffinePlugin.py
@@ -30,7 +30,7 @@ class AffinePlugin(RegistrationPlugin):
   #
   # generic settings that can (should) be overridden by the subclass
   #
-  
+
   # displayed for the user to select the registration
   name = "Affine Registration"
   tooltip = "Uses landmarks to define linear transform matrices"
@@ -104,7 +104,7 @@ class AffinePlugin(RegistrationPlugin):
       landmarkTransform.SetModeToSimilarity()
     if self.linearMode == 'Affine':
       landmarkTransform.SetModeToAffine()
-    if state.fixedFiducials.GetNumberOfFiducials() < 3:
+    if state.fixedFiducials.GetNumberOfControlPoints() < 3:
       landmarkTransform.SetModeToRigidBody()
 
     volumeNodes = (state.fixed, state.moving)

--- a/RegistrationLib/AffinePlugin.py
+++ b/RegistrationLib/AffinePlugin.py
@@ -93,7 +93,7 @@ class AffinePlugin(RegistrationPlugin):
       if state.transformed.GetTransformNodeID() != state.transform.GetID():
         state.transformed.SetAndObserveTransformNodeID(state.transform.GetID())
 
-    if not state.fixedFiducials or not state.movingFiducials:
+    if not state.fixedPoints or not state.movingPoints:
       return
 
     # try to use user selection, but fall back if not enough points are available
@@ -104,12 +104,12 @@ class AffinePlugin(RegistrationPlugin):
       landmarkTransform.SetModeToSimilarity()
     if self.linearMode == 'Affine':
       landmarkTransform.SetModeToAffine()
-    if state.fixedFiducials.GetNumberOfControlPoints() < 3:
+    if state.fixedPoints.GetNumberOfControlPoints() < 3:
       landmarkTransform.SetModeToRigidBody()
 
     volumeNodes = (state.fixed, state.moving)
-    fiducialNodes = (state.fixedFiducials,state.movingFiducials)
-    points = state.logic.vtkPointsForVolumes( volumeNodes, fiducialNodes )
+    pointListNodes = (state.fixedPoints,state.movingPoints)
+    points = state.logic.vtkPointsForVolumes( volumeNodes, pointListNodes )
     landmarkTransform.SetSourceLandmarks(points[state.moving])
     landmarkTransform.SetTargetLandmarks(points[state.fixed])
     landmarkTransform.Update()

--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -120,7 +120,7 @@ class LandmarksWidget(pqWidget):
     if self.movingView and movingIndexAttribute:
       movingIndex = int(movingIndexAttribute)
       if movingIndex < fiducialList.GetNumberOfDefinedControlPoints():
-        landmarkName = fiducialList.GetNthMarkupLabel(movingIndex)
+        landmarkName = fiducialList.GetNthControlPointLabel(movingIndex)
         self.pickLandmark(landmarkName,clearMovingView=False)
         self.emit("landmarkMoved(landmarkName)", (landmarkName,))
 
@@ -129,7 +129,7 @@ class LandmarksWidget(pqWidget):
     movingIndexAttribute = fiducialList.GetAttribute('Markups.MovingMarkupIndex')
     if movingIndexAttribute:
       movingIndex = int(movingIndexAttribute)
-      landmarkName = fiducialList.GetNthMarkupLabel(movingIndex)
+      landmarkName = fiducialList.GetNthControlPointLabel(movingIndex)
       self.pickLandmark(landmarkName,clearMovingView=False)
       self.emit("landmarkEndMoving(landmarkName)", (landmarkName,))
 
@@ -181,7 +181,7 @@ class LandmarksWidget(pqWidget):
           "New name for landmark '%s'?" % self.selectedLandmark)
       if newName != "":
         for fiducialList,index in landmarks[self.selectedLandmark]:
-          fiducialList.SetNthFiducialLabel(newName)
+          fiducialList.SetNthControlPointLabel(newName)
         self.selectedLandmark = newName
         self.updateLandmarkArray()
         self.pickLandmark(newName)

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -151,8 +151,6 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     cvpn = slicer.vtkMRMLCropVolumeParametersNode()
     cvpn.SetInterpolationMode(1)
     cvpn.SetVoxelBased(1)
-    fixedPoint = [0,]*3
-    movingPoint = [0,]*3
 
     (fixedFiducial, movingFiducial) = landmarks[state.currentLandmarkName]
 
@@ -164,7 +162,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     roiFixed = slicer.vtkMRMLAnnotationROINode()
     slicer.mrmlScene.AddNode(roiFixed)
 
-    fixedList.GetNthFiducialPosition(fixedIndex,fixedPoint)
+    fixedPoint = fixedList.GetNthControlPointPosition(fixedIndex)
     roiFixed.SetDisplayVisibility(0)
     roiFixed.SelectableOff()
     roiFixed.SetXYZ(fixedPoint)
@@ -188,7 +186,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     roiMoving = slicer.vtkMRMLAnnotationROINode()
     slicer.mrmlScene.AddNode(roiMoving)
 
-    movingList.GetNthFiducialPosition(movingIndex,movingPoint)
+    movingPoint = movingList.GetNthControlPointPosition(movingIndex)
     roiMoving.SetDisplayVisibility(0)
     roiMoving.SelectableOff()
     roiMoving.SetXYZ(movingPoint)
@@ -247,7 +245,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     tp = matrix.MultiplyPoint(fixedPoint + [1,])
     #print fixedPoint, movingPoint, tp[:3]
 
-    movingList.SetNthFiducialPosition(movingIndex, tp[0], tp[1], tp[2])
+    movingList.SetNthControlPointPosition(movingIndex, tp[0], tp[1], tp[2])
     if timing: resultEnd = time.time()
     if timing: print('Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds')
 

--- a/RegistrationLib/LocalBRAINSFitPlugin.py
+++ b/RegistrationLib/LocalBRAINSFitPlugin.py
@@ -122,9 +122,9 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
   def refineLandmark(self, state):
     """Refine the specified landmark"""
     # Refine landmark, or if none, do nothing
-    #     Crop images around the fiducial
+    #     Crop images around the point
     #     Affine registration of the cropped images
-    #     Transform the fiducial using the transformation
+    #     Transform the point using the transformation
     #
     # No need to take into account the current transformation because landmarks are in World RAS
     timing = False
@@ -134,7 +134,7 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     if state.logic.cropLogic is None:
       print("Cannot refine landmarks. CropVolume module is not available.")
 
-    if state.fixed == None or state.moving == None or state.fixedFiducials == None or  state.movingFiducials == None or state.currentLandmarkName == None:
+    if state.fixed == None or state.moving == None or state.fixedPoints == None or  state.movingPoints == None or state.currentLandmarkName == None:
       print("Cannot refine landmarks. Images or landmarks not selected.")
       return
 
@@ -152,10 +152,10 @@ class LocalBRAINSFitPlugin(RegistrationPlugin):
     cvpn.SetInterpolationMode(1)
     cvpn.SetVoxelBased(1)
 
-    (fixedFiducial, movingFiducial) = landmarks[state.currentLandmarkName]
+    (fixedPoint, movingPoint) = landmarks[state.currentLandmarkName]
 
-    (fixedList,fixedIndex) = fixedFiducial
-    (movingList, movingIndex) = movingFiducial
+    (fixedList,fixedIndex) = fixedPoint
+    (movingList, movingIndex) = movingPoint
 
     # define an roi for the fixed
     if timing: roiStart = time.time()

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -132,16 +132,16 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
   def refineLandmark(self, state):
     """Refine the specified landmark"""
     # Refine landmark, or if none, do nothing
-    #     Crop images around the fiducial
+    #     Crop images around the point
     #     Affine registration of the cropped images
-    #     Transform the fiducial using the transformation
+    #     Transform the point using the transformation
     #
     # No need to take into account the current transformation because landmarks are in World RAS
     timing = False
     if self.VerboseMode == "Verbose":
       timing = True
 
-    if state.fixed == None or state.moving == None or state.fixedFiducials == None or  state.movingFiducials == None or state.currentLandmarkName == None:
+    if state.fixed == None or state.moving == None or state.fixedPoints == None or  state.movingPoints == None or state.currentLandmarkName == None:
       print("Cannot refine landmarks. Images or landmarks not selected.")
       return
 
@@ -160,10 +160,10 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
 
     landmarks = state.logic.landmarksForVolumes(volumes)
 
-    (fixedFiducial, movingFiducial) = landmarks[state.currentLandmarkName]
+    (fixedPoint, movingPoint) = landmarks[state.currentLandmarkName]
 
-    (fixedList,fixedIndex) = fixedFiducial
-    (movingList, movingIndex) = movingFiducial
+    (fixedList,fixedIndex) = fixedPoint
+    (movingList, movingIndex) = movingPoint
 
     fixedPoint = fixedList.GetNthControlPointPosition(fixedIndex)
     movingPoint = movingList.GetNthControlPointPosition(movingIndex)

--- a/RegistrationLib/LocalSimpleITKPlugin.py
+++ b/RegistrationLib/LocalSimpleITKPlugin.py
@@ -165,11 +165,8 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
     (fixedList,fixedIndex) = fixedFiducial
     (movingList, movingIndex) = movingFiducial
 
-    fixedPoint = [0,]*3
-    movingPoint = [0,]*3
-
-    fixedList.GetNthFiducialPosition(fixedIndex,fixedPoint)
-    movingList.GetNthFiducialPosition(movingIndex,movingPoint)
+    fixedPoint = fixedList.GetNthControlPointPosition(fixedIndex)
+    movingPoint = movingList.GetNthControlPointPosition(movingIndex)
 
     # HACK transform from RAS to LPS
     fixedPoint = [-fixedPoint[0], -fixedPoint[1], fixedPoint[2]]
@@ -291,7 +288,7 @@ class LocalSimpleITKPlugin(RegistrationPlugin):
 
     # HACK transform from LPS to RAS
     updatedPoint = [-updatedPoint[0], -updatedPoint[1], updatedPoint[2]]
-    movingList.SetNthFiducialPosition(movingIndex, updatedPoint[0], updatedPoint[1], updatedPoint[2])
+    movingList.SetNthControlPointPosition(movingIndex, updatedPoint[0], updatedPoint[1], updatedPoint[2])
     if timing: resultEnd = time.time()
     if timing: print('Time for transforming landmark was ' + str(resultEnd - resultStart) + ' seconds')
 

--- a/RegistrationLib/RegistrationState.py
+++ b/RegistrationLib/RegistrationState.py
@@ -12,10 +12,10 @@ class RegistrationState:
   moving = None
   transformed = None
 
-  # MRML Markup Fiducial Nodes
-  fixedFiducials = None
-  movingFiducials = None
-  transformedFiducials = None
+  # MRML Markup Point List Nodes
+  fixedPoints = None
+  movingPoints = None
+  transformedPoints = None
 
   # MRML Linear Transform Node
   transform = None

--- a/RegistrationLib/ThinPlatePlugin.py
+++ b/RegistrationLib/ThinPlatePlugin.py
@@ -138,8 +138,8 @@ class ThinPlatePlugin(RegistrationPlugin):
     """Perform the thin plate transform using the vtkThinPlateSplineTransform class"""
 
     volumeNodes = (state.fixed, state.moving)
-    fiducialNodes = (state.fixedFiducials,state.movingFiducials)
-    points = state.logic.vtkPointsForVolumes( volumeNodes, fiducialNodes )
+    pointListNodes = (state.fixedPoints,state.movingPoints)
+    points = state.logic.vtkPointsForVolumes( volumeNodes, pointListNodes )
 
     # since this is a resample transform, source is the fixed (resampling target) space
     # and moving is the target space


### PR DESCRIPTION
Use of deprecated markups API was alerted during runtime execution starting with https://github.com/Slicer/Slicer/commit/73867d1c432842ee768ffb7693a4993070f5ff3c. This PR addresses this by using non-deprecated markups API. Originally observed runtime errors in https://slicer.cdash.org/test/20213022.