### PR TITLE
BUG: Fix developer mode issue with tooltip button

### DIFF
--- a/LandmarkRegistration.py
+++ b/LandmarkRegistration.py
@@ -66,7 +66,7 @@ class LandmarkRegistrationWidget(ScriptedLoadableModuleWidget):
       scenarios = ("Basic", "Affine", "ThinPlate", "VTKv6Picking", "ManyLandmarks")
       for scenario in scenarios:
         button = qt.QPushButton("Reload and Test %s" % scenario)
-        self.reloadAndTestButton.toolTip = "Reload this module and then run the %s self test." % scenario
+        button.toolTip = "Reload this module and then run the %s self test." % scenario
         self.reloadCollapsibleButton.layout().addWidget(button)
         button.connect('clicked()', lambda s=scenario: self.onReloadAndTest(scenario=s))
 


### PR DESCRIPTION
The self.reloadAndTestButton reference was removed in https://github.com/Slicer/Slicer/commit/b4512ab39f73bc848cb80c3581b8db665a42b4cf.

Once Slicer updates to use this commit it will actually fix https://github.com/Slicer/Slicer/issues/7194. https://github.com/pieper/CompareVolumes/commit/cb755dda78f726cf9262aa4e1f75122c72a0df2f fixed a similar issue, but not that exact issue which was reported.