### PR TITLE
BUG: Fix Qt6 incompatible API setting margin

### DIFF
--- a/RegistrationLib/Landmarks.py
+++ b/RegistrationLib/Landmarks.py
@@ -62,7 +62,7 @@ class LandmarksWidget(pqWidget):
     for landmarkName in keys:
       row = qt.QWidget()
       rowLayout = qt.QHBoxLayout()
-      rowLayout.setMargin(0)
+      rowLayout.setContentsMargins(0, 0, 0, 0)
 
       label = qt.QLabel(landmarkName)
       rowLayout.addWidget(label, 8)


### PR DESCRIPTION
setMargin is unavailable in Qt6, so use setContentsMargin which is available for both Qt6 and Qt5.

This addresses the failing py_LandmarkRegistration test when building 3D Slicer with Qt6.
```
This tests basic landmarking with two volumes ... Traceback (most recent call last):
  File "C:\S5R4\Slicer-build\lib\Slicer-5.11\qt-scripted-modules\RegistrationLib\Landmarks.py", line 198, in wrappedNodeAddedUpdate
    self.nodeAddedUpdate()
  File "C:\S5R4\Slicer-build\lib\Slicer-5.11\qt-scripted-modules\RegistrationLib\Landmarks.py", line 225, in nodeAddedUpdate
    self.updateLandmarkArray()
  File "C:\S5R4\Slicer-build\lib\Slicer-5.11\qt-scripted-modules\RegistrationLib\Landmarks.py", line 65, in updateLandmarkArray
    rowLayout.setMargin(0)
    ^^^^^^^^^^^^^^^^^^^
AttributeError: QHBoxLayout has no attribute named 'setMargin'
```